### PR TITLE
Conventionalize English in tablet preferences.

### DIFF
--- a/tablet.md
+++ b/tablet.md
@@ -1,23 +1,20 @@
 # Tablet
 
-Since Windows 8, Microsoft introduced a new API to use your tablet
-with Windows program: the pointer API. Since Aseprite v1.2.19.1 you
-can configure what API do you prefer to use:
+As of Aseprite version 1.2.19.1, you can select which Windows
+application programming interface (API) you prefer.
 
 ![Tablet section](tablet/tablet.png)
 
-* *Windows 8/10 Pointer API*: This option might be enough for most
-  modern devices, you can give a try how your tablet works with this
-  (might work better with this option than with Wintab)
-* *[Wintab](wintab.md)*: This is the default option at the moment to
-  support pressure sensitivity on older systems (Windows Vista/7) and
-  older devices.
-* *Wintab (direct packet processing)*: This option might not work well
-  in some devices, but might be useful in other devices to avoid
-  losing packets and getting smoother strokes.
+* *Windows 8/10 Pointer API*: The newer option from Microsoft, this
+  should suffice for most modern devices.
+* *[Wintab](wintab.md)*: This option is present to support pressure
+  sensitivity on older devices and operating systems (Windows Vista/7).
+* *Wintab (direct packet processing)*: This option aims to minimize
+  packet loss and to create smoother strokes. It might not work well
+  in some devices.
 
 Pressing the *OK*/*Apply* buttons will change the tablet settings
-immediately, there is no need to restart the program.
+immediately. There is no need to restart Aseprite.
 
 ---
 


### PR DESCRIPTION
I revised the English grammar to be more conventional. I did not know which of the three options was the default as of 1.2.27, so I avoided specifying.