### PR TITLE
Collate markdown docs into a PDF document with pandoc

### DIFF
--- a/.github/workflows/md-to-pdf.yml
+++ b/.github/workflows/md-to-pdf.yml
@@ -1,0 +1,35 @@
+name: Markdown to PDF
+
+on: [push, workflow_dispatch]
+
+jobs:
+  convert_via_pandoc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Create file list
+        id: files_list
+        run: |
+          echo "files=$(printf '\"%s\" ' *.md | sed 's/ \"sidebar\.md\"/ /' && printf '\"%s\" ' extensions/*.md)" > $GITHUB_OUTPUT
+          mkdir output
+      - uses: docker://pandoc/extra:latest-ubuntu
+        with:
+          args: >-
+            --output=output/aseprite-docs.pdf ${{ steps.files_list.outputs.files }}
+            --pdf-engine=lualatex
+            -f markdown_github
+            --include-in-header ./.github/workflows/pdf/header.tex
+            --include-before-body ./.github/workflows/pdf/title.tex
+            --file-scope
+            --table-of-contents
+            --number-sections
+            -V mainfont="DejaVu Sans"
+            -V mainfontoptions:"Extension=.ttf, UprightFont=*, BoldFont=*-Bold"
+            -V documentclass=article
+            -V colorlinks
+            -V urlcolor=NavyBlue
+            -V geometry:"top=2cm, bottom=1.5cm, left=2cm, right=2cm"
+      - uses: actions/upload-artifact@master
+        with:
+          name: aseprite-docs
+          path: output/aseprite-docs.pdf

--- a/.github/workflows/pdf/header.tex
+++ b/.github/workflows/pdf/header.tex
@@ -1,0 +1,6 @@
+\usepackage{listings}
+\usepackage{fancyhdr}
+\pagestyle{fancy}
+\title{Aseprite Documentation}
+\setkeys{Gin}{scale=1, height=0.4\textheight, keepaspectratio}
+\let\verbatim\undefined\let\verbatimend\undefined\lstnewenvironment{verbatim}{\lstset{breaklines}}{}

--- a/.github/workflows/pdf/title.tex
+++ b/.github/workflows/pdf/title.tex
@@ -1,0 +1,4 @@
+\date{\today}
+\maketitle
+\lhead{Aseprite Documentation}
+\rhead{\today}


### PR DESCRIPTION
Adds a GitHub Action which collates all markdown documentation files into a [single PDF doc](https://github.com/stmio/aseprite-docs/suites/12504378731/artifacts/667017187), see https://github.com/aseprite/docs/issues/3#issuecomment-1493380762. The action runs on every commit and uses pandoc to generate the document, which outputs the file to [GitHub Artifact storage](https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts).

The main downside of this document in comparison to the website is that the GIF animations display as static images.

I am happy to maintain this action into the future, let me know if you find any problems. 😄 

Closes #3 