### PR TITLE
GitHub will now display Markdown as the repo's language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.md linguist-vendored=false
+*.md linguist-generated=false
+*.md linguist-documentation=false
+*.md linguist-detectable=true


### PR DESCRIPTION
GitHub's linguistic will now detect and display markdown as a language