### PR TITLE
Fix language extension the meaning of `contributes.languages.id`

### DIFF
--- a/extensions/languages.md
+++ b/extensions/languages.md
@@ -37,7 +37,7 @@ The `contributes.languages.displayName` property was introduced in
 **Aseprite v1.3-rc5** to show the language instead of the language code/ID
 (e.g. `es`) in the *Edit > Preferences > General > Language* combobox.
 
-For the `contributes.languages.id` use an [ISO 639-1 language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
+For the `contributes.languages.id` use an [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag).
 
 ---
 


### PR DESCRIPTION
It should be [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag)

Related to: https://github.com/aseprite/aseprite/issues/3945

Additional links for reference: (May be useful for docs)


- [Microsoft - Windows Language tag](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c?redirectedfrom=MSDN)
- [Apple Developer - Language and Locale IDs](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/LanguageandLocaleIDs/LanguageandLocaleIDs.html)
- [RFC4646](https://datatracker.ietf.org/doc/html/rfc4646)
- [Letter codes of cultures (languages, countries / regions) - list](https://www.venea.net/web/culture_code)
