### PR TITLE
Improvements to generated PDF document

### DIFF
--- a/.github/workflows/md-to-pdf.yml
+++ b/.github/workflows/md-to-pdf.yml
@@ -20,6 +20,7 @@ jobs:
             -f markdown_github
             --include-in-header ./.github/workflows/pdf/header.tex
             --include-before-body ./.github/workflows/pdf/title.tex
+            --lua-filter ./.github/workflows/pdf/link-gifs.lua
             --file-scope
             --table-of-contents
             --number-sections

--- a/.github/workflows/md-to-pdf.yml
+++ b/.github/workflows/md-to-pdf.yml
@@ -10,12 +10,12 @@ jobs:
       - name: Create file list
         id: files_list
         run: |
-          echo "files=$(printf '\"%s\" ' *.md | sed 's/ \"sidebar\.md\"/ /' && printf '\"%s\" ' extensions/*.md)" > $GITHUB_OUTPUT
+          echo "files=$(printf '\"%s\" ' *.md | sed 's/ \"sidebar\.md\"/ /' | sed 's/ \"overview\.md\"/ /' && printf '\"%s\" ' extensions/*.md)" > $GITHUB_OUTPUT
           mkdir output
       - uses: docker://pandoc/extra:latest-ubuntu
         with:
           args: >-
-            --output=output/aseprite-docs.pdf ${{ steps.files_list.outputs.files }}
+            --output=output/aseprite-docs.pdf "overview.md" ${{ steps.files_list.outputs.files }}
             --pdf-engine=lualatex
             -f markdown_github
             --include-in-header ./.github/workflows/pdf/header.tex

--- a/.github/workflows/pdf/link-gifs.lua
+++ b/.github/workflows/pdf/link-gifs.lua
@@ -1,0 +1,20 @@
+function Image(img)
+    if img.src:match("^.+(%..+)$") == ".gif" then
+        local link
+
+        if string.find(img.src, "www") then
+            -- Image source is already a URL
+            link = "https:" .. img.src
+        else
+            -- Image source is a local file
+            link = "https://aseprite.org/docs/" .. img.src
+        end
+
+        return pandoc.Link(
+            pandoc.Image(img.caption, img.src, img.title, img.attr),
+            link
+        )
+    else
+        return img
+    end
+end

--- a/.github/workflows/pdf/title.tex
+++ b/.github/workflows/pdf/title.tex
@@ -2,3 +2,10 @@
 \maketitle
 \lhead{Aseprite Documentation}
 \rhead{\today}
+\begin{center}
+    This is the PDF version of the \href{https://aseprite.org/docs/}{online Aseprite documentation}.
+    The latest version of this document can be downloaded from the \href{https://github.com/aseprite/docs/}{docs GitHub repository}.
+
+    Some images in this document are GIF animations, which can not be played when embedded in a PDF. 
+    GIFs are linked to their online counterpart, so you can click the image to view the animation in your browser.
+\end{center}


### PR DESCRIPTION
This PR fixes a few errors with the automatically generated PDF documents, as discussed in #32:

- Moves the "Aseprite Help" (`overview.md`) chapter to the top of the document.
- The main drawback of the PDF in its current state is the lack of GIF animations. This adds a [pandoc Lua Filter](https://pandoc.org/lua-filters.html), which programmatically adds a hyperlink to the online copy of the GIF, so they can be viewed in the user's browser when the GIF is clicked.
- Add a notice at the top of the document explaining the ability to view GIF animations 
