### PR TITLE
Added note about outputting JSON data to stdout

### DIFF
--- a/cli.md
+++ b/cli.md
@@ -222,6 +222,11 @@ format. [Output example.](https://gist.github.com/dacap/db18e5747a4b6e208d3c)
 
 See [--sheet](#sheet) option to change the destination of the sprite sheet image.
 
+The JSON data can also be written directly to stdout, by explicitly
+using an empty filename, i.e. `--data=""`.
+
+    aseprite.exe ... --data="" animations.ase
+
 ## --format
 
 Changes the format used to shave the sprite sheet data specified in


### PR DESCRIPTION
Crossing my fingers that this is intentional behavior, but simply not documented. Because I was searching for a way to get the JSON data without first writing it to disk.