### PR TITLE
Update cli.md

### DIFF
--- a/cli.md
+++ b/cli.md
@@ -722,6 +722,6 @@ For Mac users, you could create a `convert.sh`:
 
 Aseprite binary is installed in the following directories.
 
-- Mac `~/Library/Application Support/Steam/steamapps/common/Aseprite/Aseprite.app/Contents/MacOS/aseprite`
+- Mac `~/Library/Application\ Support/Steam/steamapps/common/Aseprite/Aseprite.app/Contents/MacOS/aseprite`
 - Windows `C:\Program Files (x86)\Steam\steamapps\common\Aseprite\Aseprite.exe`
 - Ubuntu `~/.steam/debian-installation/steamapps/common/Aseprite/aseprite`


### PR DESCRIPTION
`~/Library/Application Support/Steam/steamapps/common/Aseprite/Aseprite.app/Contents/MacOS/aseprite` because of the space, this path does not work, and an error occurs `zsh: no such file or directory: /Users/user/Library/Application`

Correct path is: ~/Library/Application\ Support/Steam/steamapps/common/Aseprite/Aseprite.app/Contents/MacOS/aseprite