### PR TITLE
Add 'Command' explanation to `.aseprite-keys` documentation

### DIFF
--- a/extensions/keys.md
+++ b/extensions/keys.md
@@ -47,6 +47,13 @@ can be created / exported from [Edit > Keyboard Shortcuts](keyboard-shortcuts.md
 </keyboard>
 ```
 
+When creating a keyboard shortcut for custom functionality in an 
+aseprite extension, you must create a New Command for it first.
+You can then use that Command's title to bind the functionality 
+to the shortcut using the `.aseprite-keys` file.
+
+You can read more on how to create Commands in the [API documentation](https://www.aseprite.org/api/plugin#pluginnewcommand)
+
 ---
 
 **SEE ALSO**


### PR DESCRIPTION
Added a paragraph to explain that you need to create custom commands to be able to hook up custom key shortcuts to extension functionality.

Added link to API documentation for :NewCommand(). Since it links from the Docs repository to the API repository, I had to use a hardcoded website link. If there is a better way to do that, let me know


_This time actually from a branch rather than my main repository!_
A recommit from which I erroneously closed by overwriting the original changes https://github.com/aseprite/docs/pull/52